### PR TITLE
Update 9990-winevent-catchall-output.conf

### DIFF
--- a/docker/helk-logstash/pipeline/9990-winevent-catchall-output.conf
+++ b/docker/helk-logstash/pipeline/9990-winevent-catchall-output.conf
@@ -1,5 +1,5 @@
 output {
-  if [@metadata][helk_parsed] == "yes" and [log_name] != "Microsoft-Windows-Sysmon/Operational" and [log_name] != "Security" and [log_name] != "System" and [log_name] != "Application" and [source_name] != "Microsoft-Windows-PowerShell" and [source_name] != "PowerShell" and [source] != "/var/log/osquery/osqueryd.results.log" and [@metadata][kafka][topic] != "SYSMON_JOIN" and [@metadata][helk_input_source] != "mitre_attack" {
+  if [type] == "wineventlog" and [@metadata][helk_parsed] == "yes" and [log_name] != "Microsoft-Windows-Sysmon/Operational" and [log_name] != "Security" and [log_name] != "System" and [log_name] != "Application" and [source_name] != "Microsoft-Windows-PowerShell" and [source_name] != "PowerShell" and [source] != "/var/log/osquery/osqueryd.results.log" and [@metadata][kafka][topic] != "SYSMON_JOIN" and [@metadata][helk_input_source] != "mitre_attack" {
     elasticsearch {
       hosts => ["helk-elasticsearch:9200"]
       index => "logs-endpoint-winevent-additional-%{+YYYY.MM.dd}"


### PR DESCRIPTION
**What is this PR for?**
Added check whether the type is wineventlog, as the MITRE data also got injected in the catch all output.

**What type of PR is it?**
[Bug Fix]

**How should this be tested?**
Restart Logstash and see that MITRE data doesn't end up in logs-endpoint-additional

**Questions:**
* Do the licenses files need update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
